### PR TITLE
[change] fixed typo

### DIFF
--- a/chat_client_check/check.py
+++ b/chat_client_check/check.py
@@ -88,7 +88,7 @@ def start_script():
     return client_process, output_buffer
 
 def log_in(client_name=generate_name()):
-    expected_output = f'Succesfully logged in as {client_name}!'
+    expected_output = f'Successfully logged in as {client_name}!'
 
     client_process, output_buffer = start_script()
     client_process.sendline(client_name)


### PR DESCRIPTION
In the chat_client test file, there is a typo in the not_restart_failed_attempt function. The expected output has 1 's' instead of 2 's' for successfully.