### PR TITLE
fix: reset ANSI color at the end of message

### DIFF
--- a/chat_client_check/check.py
+++ b/chat_client_check/check.py
@@ -370,13 +370,13 @@ class TestCase():
             self.test_func()
 
             if not disable_colors:
-                print(f'\033[92m[ \u2713 ] \033[30m{self.test_id}. {self.test_msg}. \033[92mSuccess! \033[30m')
+                print(f'\033[92m[ \u2713 ] \033[30m{self.test_id}. {self.test_msg}. \033[92mSuccess! \033[0m')
             else:
                 print(f'[ \u2713 ] {self.test_id}. {self.test_msg}. Success!')
 
         except TypeError as e: # originates from pexpect .before if script terminates. except for more readable error message
             if not disable_colors:
-                print(f'\033[91m[ x ] \033[30m{self.test_id}. {self.test_msg} \033[91mFailed! \033[30m The list of tags is {tags_string} \nYour client did not start or connected to a wrong server port \033[30m')
+                print(f'\033[91m[ x ] \033[30m{self.test_id}. {self.test_msg} \033[91mFailed! \033[30m The list of tags is {tags_string} \nYour client did not start or connected to a wrong server port \033[0m')
             else:
                 print(f'[ x ] {self.test_id}. {self.test_msg} Failed! The list of tags is {tags_string} \nYour client did not start or connected to a wrong server port')
             
@@ -384,7 +384,7 @@ class TestCase():
 
         except Exception as e:
             if not disable_colors:
-                print(f'\033[91m[ x ] \033[30m{self.test_id}. {self.test_msg} \033[91mFailed! \033[30m The list of tags is {tags_string} \nError message is {e} \033[30m')
+                print(f'\033[91m[ x ] \033[30m{self.test_id}. {self.test_msg} \033[91mFailed! \033[30m The list of tags is {tags_string} \nError message is {e} \033[0m')
             else:
                 print(f'[ x ] {self.test_id}. {self.test_msg} Failed! The list of tags is {tags_string} \nError message is {e}')
 

--- a/dns_check/check.py
+++ b/dns_check/check.py
@@ -117,7 +117,7 @@ class TestCase():
             self.test_func()
             
             if not disable_colors:
-                print(f'\033[92m[ \u2713 ] \033[30m{self.test_id}. {self.test_msg}. \033[92mSuccess! \033[30m')
+                print(f'\033[92m[ \u2713 ] \033[30m{self.test_id}. {self.test_msg}. \033[92mSuccess! \033[0m')
             else:
                 print(f'[ \u2713 ] {self.test_id}. {self.test_msg}. Success!')
         except Exception as e:
@@ -128,7 +128,7 @@ class TestCase():
                 pass
 
             if not disable_colors:
-                print(f'\033[91m[ x ] \033[30m{self.test_id}. {self.test_msg} \033[91mFailed! \033[30m The list of tags is {tags_string} \nError message is {e} \nThe server output is {server_process.before} \033[30m')
+                print(f'\033[91m[ x ] \033[30m{self.test_id}. {self.test_msg} \033[91mFailed! \033[30m The list of tags is {tags_string} \nError message is {e} \nThe server output is {server_process.before} \033[0m')
             else:
                 print(f'[ x ] {self.test_id}. {self.test_msg} Failed! The list of tags is {tags_string} \nError message is {e} \nThe server output is {server_process.before}')
             

--- a/http_server_check/check.py
+++ b/http_server_check/check.py
@@ -320,7 +320,7 @@ class TestCase():
             self.test_func()
             
             if not disable_colors:
-                print(f'\033[92m[ \u2713 ] \033[30m{self.test_id}. {self.test_msg}. \033[92mSuccess! \033[30m')
+                print(f'\033[92m[ \u2713 ] \033[30m{self.test_id}. {self.test_msg}. \033[92mSuccess! \033[0m')
             else:
                 print(f'[ \u2713 ] {self.test_id}. {self.test_msg}. Success! ')
 
@@ -328,7 +328,7 @@ class TestCase():
             success = False
             
             if not disable_colors:
-                print(f'\033[91m[ x ] \033[30m{self.test_id}. {self.test_msg} \033[91mFailed! \033[30m The list of tags is {tags_string} \nYour server did not start \033[30m')
+                print(f'\033[91m[ x ] \033[30m{self.test_id}. {self.test_msg} \033[91mFailed! \033[30m The list of tags is {tags_string} \nYour server did not start \033[0m')
             else:
                 print(f'[ x ] {self.test_id}. {self.test_msg} Failed! The list of tags is {tags_string} \nYour server did not start')
         
@@ -336,7 +336,7 @@ class TestCase():
             success = False
 
             if not disable_colors:
-                print(f'\033[91m[ x ] \033[30m{self.test_id}. {self.test_msg} \033[91mFailed! \033[30m The list of tags is {tags_string} \nError message is {e} \033[30m')
+                print(f'\033[91m[ x ] \033[30m{self.test_id}. {self.test_msg} \033[91mFailed! \033[30m The list of tags is {tags_string} \nError message is {e} \033[0m')
             else:
                 print(f'[ x ] {self.test_id}. {self.test_msg} Failed! The list of tags is {tags_string} \nError message is {e}')
 

--- a/server_check/check.py
+++ b/server_check/check.py
@@ -339,7 +339,7 @@ class TestCase():
             server_process, _ = start_server()
         except:
             if not disable_colors:
-                print(f'\033[91m[ x ] \033[30m{self.test_id}. {self.test_msg} \033[91mFailed! \033[30m The list of tags is {tags_string} \nError message is the server did not start. Please make sure your server prints Server is on on startup \033[30m')
+                print(f'\033[91m[ x ] \033[30m{self.test_id}. {self.test_msg} \033[91mFailed! \033[30m The list of tags is {tags_string} \nError message is the server did not start. Please make sure your server prints Server is on on startup \033[0m')
             else:
                 print(f'[ x ] {self.test_id}. {self.test_msg} Failed! The list of tags is {tags_string} \nError message is {e} \nThe server output is {server_process.before}')
             
@@ -349,7 +349,7 @@ class TestCase():
             self.test_func()
             
             if not disable_colors:
-                print(f'\033[92m[ \u2713 ] \033[30m{self.test_id}. {self.test_msg}. \033[92mSuccess! \033[30m')
+                print(f'\033[92m[ \u2713 ] \033[30m{self.test_id}. {self.test_msg}. \033[92mSuccess! \033[0m')
             else:
                 print(f'[ \u2713 ] {self.test_id}. {self.test_msg}. Success!')
         
@@ -357,7 +357,7 @@ class TestCase():
             success = False
 
             if not disable_colors:
-                print(f'\033[91m[ x ] \033[30m{self.test_id}. {self.test_msg} \033[91mFailed! \033[30m The list of tags is {tags_string} \nYour server did not start \033[30m')
+                print(f'\033[91m[ x ] \033[30m{self.test_id}. {self.test_msg} \033[91mFailed! \033[30m The list of tags is {tags_string} \nYour server did not start \033[0m')
             else:
                 print(f'[ x ] {self.test_id}. {self.test_msg} Failed! The list of tags is {tags_string} \nYour server did not start')
 
@@ -368,7 +368,7 @@ class TestCase():
                 pass
 
             if not disable_colors:
-                print(f'\033[91m[ x ] \033[30m{self.test_id}. {self.test_msg} \033[91mFailed! \033[30m The list of tags is {tags_string} \nError message is {e} \nThe server output is {server_process.before} \033[30m')
+                print(f'\033[91m[ x ] \033[30m{self.test_id}. {self.test_msg} \033[91mFailed! \033[30m The list of tags is {tags_string} \nError message is {e} \nThe server output is {server_process.before} \033[0m')
             else:
                 print(f'[ x ] {self.test_id}. {self.test_msg} Failed! The list of tags is {tags_string} \nError message is {e} \nThe server output is {server_process.before}')
             

--- a/unreliable_chat_check/check.py
+++ b/unreliable_chat_check/check.py
@@ -376,13 +376,13 @@ class TestCase():
         try:
             self.test_func()
             if not disable_colors:
-                print(f'\033[92m[ \u2713 ] \033[30m{self.test_id}. {self.test_msg}. \033[92mSuccess! \033[30m')
+                print(f'\033[92m[ \u2713 ] \033[30m{self.test_id}. {self.test_msg}. \033[92mSuccess! \033[0m')
             else:
                 print(f'[ \u2713 ] {self.test_id}. {self.test_msg}. Success!')
         
         except TypeError as e: # originates from pexpect .before if script terminates. except for more readable error message
             if not disable_colors:
-                print(f'\033[91m[ x ] \033[30m{self.test_id}. {self.test_msg} \033[91mFailed! \033[30m The list of tags is {tags_string} \nYour client did not start or connected to a wrong server port \033[30m')
+                print(f'\033[91m[ x ] \033[30m{self.test_id}. {self.test_msg} \033[91mFailed! \033[30m The list of tags is {tags_string} \nYour client did not start or connected to a wrong server port \033[0m')
             else:
                 print(f'[ x ] {self.test_id}. {self.test_msg} Failed! The list of tags is {tags_string} \nYour client did not start or connected to a wrong server port')
             
@@ -390,7 +390,7 @@ class TestCase():
 
         except Exception as e:
             if not disable_colors:
-                print(f'\033[91m[ x ] \033[30m{self.test_id}. {self.test_msg} \033[91mFailed! \033[30m The list of tags is {tags_string} \nError message is {e} \033[30m')
+                print(f'\033[91m[ x ] \033[30m{self.test_id}. {self.test_msg} \033[91mFailed! \033[30m The list of tags is {tags_string} \nError message is {e} \033[0m')
             else:
                 print(f'[ x ] {self.test_id}. {self.test_msg} Failed! The list of tags is {tags_string} \nError message is {e}')
             


### PR DESCRIPTION
Currently, the messages are ended with a black color ANSI code, it results in messed up output after the user has run the command:
<img width="500" alt="Screenshot of output after the messed up ANSI codes" src="https://github.com/atlarge-research/cn-lab-student/assets/75177432/5c0d57b9-ec89-4627-969c-3b8fe0a099f7">

This resets the ANSI colors at the end of a message print using [`\033[0m`](https://stackoverflow.com/a/33206814), and thus fixing the issue:
<img width="500" alt="Screenshot of output with the PR applied" src="https://github.com/atlarge-research/cn-lab-student/assets/75177432/da87ec1a-2e9e-4f50-9c36-2014fbc976be">

As much as I disagree about the color of choice (black) because of poor contrast in many terminals, this simply fixes the issue of ANSI color codes impacting the user's command line after running the tools.