### PR TITLE
Automatic building and publishing of Docker images (GitHub Actions)

### DIFF
--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -1,0 +1,25 @@
+name: Release dev image
+on:
+  push:
+    branches:
+      - 'master'
+jobs:
+  build_and_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v2
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build image and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:dev

--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -2,7 +2,7 @@ name: Release dev image
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
 jobs:
   build_and_release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -31,9 +31,9 @@ jobs:
       - name: Build image and push
         uses: docker/build-push-action@v3
         env:
-          IMAGE_TAG: ${{ github.event_name != 'workflow_dispatch' && env.imageTag || inputs.build_id }}
+          IMAGE_TAG: ${{ github.event_name != 'workflow_dispatch' && inputs.build_id || env.imageTag }}
         with:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/${{ github.repository }}:${IMAGE_TAG}
+          tags: ghcr.io/${{ github.repository }}:${{ env.IMAGE_TAG }}

--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -1,4 +1,4 @@
-name: Release dev image
+name: Release docker image
 on:
   push:
     branches:

--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Build image and push
         uses: docker/build-push-action@v3
         env:
-          IMAGE_TAG: ${{ github.event_name != 'workflow_dispatch' && inputs.build_id || env.imageTag }}
+          IMAGE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.imageTag || env.DEV_TAG }}
         with:
           context: .
           push: true

--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -36,4 +36,4 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/${{ github.repository }}:${{ env.IMAGE_TAG }}
+          tags: ghcr.io/${{ github.repository }}:${IMAGE_TAG}

--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -3,6 +3,15 @@ on:
   push:
     branches:
       - 'main'
+  workflow_dispatch:
+    inputs:
+      imageTag:
+        description: 'Docker Image tag'
+        required: true
+        default: 'latest'
+        type: string
+env:
+  DEV_TAG: dev
 jobs:
   build_and_release:
     runs-on: ubuntu-latest
@@ -21,8 +30,10 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build image and push
         uses: docker/build-push-action@v3
+        env:
+          IMAGE_TAG: ${{ github.event_name != 'workflow_dispatch' && env.imageTag || inputs.build_id }}
         with:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/${{ github.repository }}:dev
+          tags: ghcr.io/${{ github.repository }}:${{ env.IMAGE_TAG }}

--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -12,6 +12,9 @@ on:
         type: string
 env:
   DEV_TAG: dev
+concurrency:
+  group: ${{ github.event_name }}
+  cancel-in-progress: true
 jobs:
   build_and_release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -9,17 +9,20 @@ jobs:
     steps:
       - name: Clone repo
         uses: actions/checkout@v2
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v2
       - name: Setup Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build image and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ghcr.io/${{ github.repository }}:dev


### PR DESCRIPTION
This PR enables automatic building and publishing of Docker images, tagged with:
- `dev` in case of any push on the `main` branch
- `latest` (or whatever given tag) when manually triggering the workflow

built for both `amd64` and `arm64`, utilizing GitHub's Actions, which are free for public repositories.

As Docker defaults to the `latest` tag, limiting the number of releases is crucial. We do not want students to download a new image for every commit, only when it makes sense to do so. As such, automatic builds are released with the `dev` tag, while manual builds (triggered though the GitHub UI) can use any given tag (defaults to `latest`), as long as it conforms to Docker rules.

As such, students would not need to build the image manually but would simply be able to pull the published image.

The image would be accessible through `docker pull ghcr.io/USER/REPOSITORY:TAG`, in case of this repo: `docker pull ghcr.io/atlarge-research/cn-lab-student`

Even though I disagree with the base image of choice (Ubuntu), and the lack of `--no-install-recommends` with the `apt` command, both due to the **considerable** unnecessary increase in size, this simply adds automatic building.

### Making the package public
It might be that the default visiblity of the "package" (image) is private, if that is the case, one must [click on the package](https://github.com/atlarge-research/cn-lab-student/assets/75177432/cc972537-ba53-4412-a0cd-42eb7f771760), go into [the package settings](https://github.com/atlarge-research/cn-lab-student/assets/75177432/84400a0a-1bb6-4287-a18a-ec859451ad54), and [change the visibility](https://github.com/atlarge-research/cn-lab-student/assets/75177432/40c529e5-85a4-4b80-aed5-f64cf786aef4) to [public](https://github.com/atlarge-research/cn-lab-student/assets/75177432/4be69600-9eea-4097-b74e-85db98c0137f).

### Triggering a manual release

<img width="801" alt="Screenshot 2024-04-03 at 14 49 26" src="https://github.com/atlarge-research/cn-lab-student/assets/75177432/64d9c484-d963-4925-b2da-001f3d76dab9">




