### PR TITLE
Fixed send_message_before_login

### DIFF
--- a/server_check/check.py
+++ b/server_check/check.py
@@ -315,7 +315,7 @@ def send_message_before_login():
     client_name_1 = generate_name()
 
     expected_output = "Error: Unknown issue in previous message header."
-    client_process.sendline(f'@{client_name_1} {generate_message(16, 32)}')
+    client_process.sendline(f'SEND {client_name_1} {generate_message(16, 32)}')
 
     handle_pexpect(client_process, [client_process], expected_output, output_buffer, "sending a message before logging in")
 


### PR DESCRIPTION
the test case Chat_server_016 was not working correctly.

- Issue : Client did not send anything to server
- Likely cause: 
       - Client blocks user from entering special characters for the username.
       - Test sends the command "@username message" instead of entering username
       - client rejects this because of special symbol and does not send username to server.
- Fix: 
       - Replaced the @ symbol with SEND. 

VUnet ID = tfr216