### PR TITLE
Test Folder Restructure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,10 @@ WORKDIR /home/compnet
 
 COPY . /home/compnet/
 
+RUN rm /home/compnet/chat_client_check/client.py \
+    /home/compnet/dns_check/dns.py \
+    /home/compnet/server_check/server.py \
+    /home/compnet/http_server_check/server.py \
+    /home/compnet/unreliable_chat_check/client.py
+
 RUN pip install -r requirements.txt

--- a/chat_client_check/check.py
+++ b/chat_client_check/check.py
@@ -9,6 +9,8 @@ from pexpect.exceptions import TIMEOUT as TimeoutException, EOF as EndOfFileExce
 SERVER_ADDRESS = '127.0.0.1'
 SERVER_PORT = 5378
 
+STUDENT_FILE_PATH = "../student/chat_client_check/client.py"
+
 class TestException(Exception):
     pass
 
@@ -84,7 +86,7 @@ def execute_and_detach(cmd):
 
 def start_script():
     expected_output = 'Welcome to Chat Client. Enter your login:'
-    client_process = pexpect.spawn(f'python3 client.py --address "{SERVER_ADDRESS}" --port {SERVER_PORT}', encoding='utf-8')
+    client_process = pexpect.spawn(f'python3 {STUDENT_FILE_PATH} --address "{SERVER_ADDRESS}" --port {SERVER_PORT}', encoding='utf-8')
 
     output_buffer = handle_pexpect(client_process, [client_process], expected_output, "", "starting client script")
 
@@ -264,7 +266,7 @@ def check_name():
     return client_process, output_buffer
 
 def verify_file_for_sendall():
-    file_path = os.path.join(os.getcwd(), "client.py")
+    file_path = os.path.join(os.getcwd(), STUDENT_FILE_PATH)
 
     try:
         with open(file_path, 'r') as file:

--- a/dns_check/check.py
+++ b/dns_check/check.py
@@ -7,6 +7,7 @@ import time
 SERVER_ADDRESS = '127.0.0.1'
 SERVER_PORT = 8000
 IPV4ONLY = False
+STUDENT_FILE_PATH = "../student/dns_check/dns.py"
 
 class TestException(Exception):
     pass
@@ -41,7 +42,7 @@ def handle_pexpect(child_process, processes_to_terminate, expect_string, output_
     return output_buffer
 
 def start_server():
-    return execute_and_detach(f'python3 dns.py --ipv4only {IPV4ONLY} --address {SERVER_ADDRESS} --port {SERVER_PORT}')
+    return execute_and_detach(f'python3 {STUDENT_FILE_PATH} --ipv4only {IPV4ONLY} --address {SERVER_ADDRESS} --port {SERVER_PORT}')
 
 
 def execute_and_detach(cmd):

--- a/http_server_check/check.py
+++ b/http_server_check/check.py
@@ -12,6 +12,7 @@ from bs4 import BeautifulSoup
 
 SERVER_ADDRESS = "127.0.0.1"
 SERVER_PORT = 8000
+STUDENT_FILE_PATH = "../student/http_server_check/server.py"
 
 def generate_name():
     return ''.join(random.choice(string.ascii_letters) for _ in range(random.randint(8, 16)))
@@ -68,7 +69,7 @@ def handle_requests_request(page_path, data):
         raise TestException(f'error when requesting {page_path} with method POST: {e}')
 
 def start_server():
-    server_process = execute_and_detach(f'python3 server.py --address {SERVER_ADDRESS} --port {SERVER_PORT}')
+    server_process = execute_and_detach(f'python3 {STUDENT_FILE_PATH} --address {SERVER_ADDRESS} --port {SERVER_PORT}')
     EXPECTED_OUTPUT = f'Serving HTTP on port {SERVER_PORT}'
 
     output_buffer = handle_pexpect(server_process, [server_process], EXPECTED_OUTPUT, "", "starting a server")

--- a/server_check/check.py
+++ b/server_check/check.py
@@ -10,6 +10,7 @@ import time
 CLIENT_FOLDER_PATH = './'
 ADDRESS = "127.0.0.1"
 PORT = 5378
+STUDENT_FILE_PATH = "../student/server_check/server.py"
 
 def generate_name():
     return ''.join(random.choice(string.ascii_letters) for _ in range(random.randint(8, 16)))
@@ -50,7 +51,7 @@ def handle_pexpect(child_process, processes_to_terminate, expect_string, output_
     return output_buffer
 
 def start_server():
-    server_process = execute_and_detach(f'python3 server.py --address "{ADDRESS}" --port {PORT}')
+    server_process = execute_and_detach(f'python3 {STUDENT_FILE_PATH} --address "{ADDRESS}" --port {PORT}')
     expected_output = "Server is on"
 
     output_buffer = handle_pexpect(server_process, [server_process], expected_output, "", "starting a server")
@@ -281,7 +282,7 @@ def send_message_to_unknown():
     return client_process, output_buffer
 
 def verify_file_for_sendall():
-    file_path = os.path.join(os.getcwd(), "server.py")
+    file_path = os.path.join(os.getcwd(), STUDENT_FILE_PATH)
 
     try:
         with open(file_path, 'r') as file:

--- a/unreliable_chat_check/check.py
+++ b/unreliable_chat_check/check.py
@@ -13,6 +13,7 @@ class TestException(Exception):
 SERVER_DIRECTORY = "./"
 SERVER_ADDRESS = "127.0.0.1"
 SERVER_PORT = 5382
+STUDENT_FILE_PATH = "../student/unreliable_chat_check/client.py"
 
 def generate_name():
     return ''.join(random.choice(string.ascii_letters) for _ in range(random.randint(8, 16)))
@@ -88,7 +89,7 @@ def execute_and_detach(cmd):
 
 def start_script():
     expected_output = f'Welcome to Chat Client. Enter your login:'
-    client_process = pexpect.spawn(f'python3 client.py --address "{SERVER_ADDRESS}" --port {SERVER_PORT}', encoding='utf-8')
+    client_process = pexpect.spawn(f'python3 {STUDENT_FILE_PATH} --address "{SERVER_ADDRESS}" --port {SERVER_PORT}', encoding='utf-8')
 
     output_buffer = handle_pexpect(client_process, [client_process], f'{expected_output}', "", "starting the client script")
 
@@ -272,7 +273,7 @@ def check_name():
     return client_process, output_buffer
 
 def verify_file_for_sendall():
-    file_path = os.path.join(os.getcwd(), "client.py")
+    file_path = os.path.join(os.getcwd(), STUDENT_FILE_PATH)
 
     try:
         with open(file_path, 'r') as file:


### PR DESCRIPTION
At the moment, the CWD is mounted into the Dockerfile at `/home/compnet` which overwrites the tests which are already in the container. This means that, in order for the tests that are run locally to be up-to-date with those in GitHub, the students need to constantly re-download from GH every time we make a change.

This PR mounts the student code into a separate folder (`/home/compnet/student`), and changes the file paths in the `check.py` tests to run those implementations. 

Because students pull our package from GH (as per Trix's PR), this should mean that they always have the latest tests.

This means that instead of running:
`docker run --rm --network="host" -v $(pwd):/home/compnet -it ghcr.io/atlarge-research/cn-lab-student:latest`
Students must run (see mounting point difference):
`docker run --rm --network="host" -v $(pwd):/home/compnet/student -it ghcr.io/atlarge-research/cn-lab-student:latest`