### PR TITLE
Changed one test in server_check

### DIFF
--- a/server_check/check.py
+++ b/server_check/check.py
@@ -314,7 +314,7 @@ def send_message_before_login():
     client_process, output_buffer = start_script()
     client_name_1 = generate_name()
 
-    expected_output = "Error: Unknown issue in previous message header."
+    expected_output = "That username contains disallowed characters."
     client_process.sendline(f'@{client_name_1} {generate_message(16, 32)}')
 
     handle_pexpect(client_process, [client_process], expected_output, output_buffer, "sending a message before logging in")


### PR DESCRIPTION
The test is named send_message_before_login and is intended to show that you are not allowed to log in with a username that contains disallowed characters. Instead, it was supposedly testing for BAD-RQST-HDR.