### PR TITLE
[change] changed server port to correct port number

### DIFF
--- a/unreliable_chat_check/BrokenChatServerLocal.go
+++ b/unreliable_chat_check/BrokenChatServerLocal.go
@@ -241,7 +241,7 @@ func (b *BrokenMessageOutputStream) WriteAndLog(msg []byte, addr net.Addr) {
 
 func main() {
 	address := flag.String("address", "127.0.0.1", "The Chat Server Address.")
-	port := flag.String("port", "8888", "The Chat Server Port.")
+	port := flag.String("port", "5382", "The Chat Server Port.")
 
 	burst := flag.Float64("burst", 0, "The probability of message burst. Works only if executed locally")
 	delay := flag.Float64("delay", 0, "Message delay. Works only if executed locally")


### PR DESCRIPTION
The go server in unreliable_chat_check starts a server on port 8888. The assignment description says that the tester runs the server on port 5382. The chat client also connects to the port 5382.

VU net ID: bay208