### PR TITLE
Fixed mosaic_support.sh

### DIFF
--- a/http2-trace-analysis/mosaic_support.sh
+++ b/http2-trace-analysis/mosaic_support.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+DEFAULT_WEBSITE="about:blank"
+# Point to current directory
+export SSLKEYLOGFILE="$(dirname $0)/keylogfile.txt"
+
+case "$(uname -s)" in
+Linux*)
+	BROWSER_BINS=(chromium google-chrome firefox brave librewolf icecat)
+	# Kill all browser processes
+	for BROWSER_BIN in "${BROWSER_BINS[@]}"; do
+		if command -v "$BROWSER_BIN" &>/dev/null; then
+			killall -9 "$BROWSER_BIN" &>/dev/null
+		fi
+	done
+
+	WEBSITE="$@"
+	if [ -z "$WEBSITE" ] || [[ ! "$WEBSITE" =~ ^http ]]; then
+		WEBSITE="$DEFAULT_WEBSITE"
+		echo "Fallback to $DEFAULT_WEBSITE"
+	fi
+
+	# Open default browser
+	xdg-open "$WEBSITE"
+	;;
+Darwin*)
+	open "$@"
+	;;
+esac


### PR DESCRIPTION
Currently, both `mosaic-support` scripts open `chrome` by default and make it very hard for users that do not have a good understanding of filesystems to locate the `keylogfile.txt` file.

This pull request adds support for opening the default browser instead and also set the `SSLKEYLOGFILE` environment variable to point to the current directory.

The changes are only implemented for Linux (and partially for Mac), but I intend to modify both the Mac and Windows part of the script(s).