### PR TITLE
Make Docker image smaller (no-recommends + Headless JRE)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3.10 \
     python3-pip \
     strace \
-    openjdk-17-jdk \
+    openjdk-17-jre-headless \
     golang-go \
     dnsutils
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:jammy
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     netcat \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     strace \
     openjdk-17-jre-headless \
     golang-go \
-    dnsutils
+    dnsutils \
+    nano \
+    tmux
 
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:latest
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     netcat \
     software-properties-common \
     python3.10 \


### PR DESCRIPTION
To make the Docker image lighter:
- I've removed "recommended" but useless packages (~300MB)
- I've also changed the Java JDK to a Headless JRE which uses considerably less space (~269MB)

The Go toolchain could still be removed by building a static binary, but this would require some more work throughout the codebase.