### PR TITLE
Unified hello handling with chat server requirements

### DIFF
--- a/unreliable_chat_check/BrokenChatServerLocal.go
+++ b/unreliable_chat_check/BrokenChatServerLocal.go
@@ -369,7 +369,11 @@ func handleHello(message string, addr net.Addr, output BrokenMessageOutputStream
 		} else { // HELLO-FROM format is correct. Enough space for new client
 			name := match[3]
 			if cb.IsKnown(name) { // But this username already exists
-				output.Send(addr, ReplyInUse)
+				if cb.nameToAddr[name] == addr.String(){ // check if username belongs to this address
+					output.Send(addr, ReplyBadHdr)
+				} else {
+					output.Send(addr, ReplyInUse)
+				}
 			} else { // We don't know this user
 				cb.Add(addr, name)
 				output.Send(addr, "HELLO "+name+"\n")
@@ -377,10 +381,8 @@ func handleHello(message string, addr net.Addr, output BrokenMessageOutputStream
 		}
 	} else {
 		if match := regexDisallowedNameCharacters.FindStringSubmatch(message); match != nil {
-			output.Send(addr, ReplyBadHdr)
-		} else {
 			output.Send(addr, ReplyBadBody)
-		}
+		} 
 	}
 }
 


### PR DESCRIPTION
I made two changes to the handleHello function, so that it works as specified in the lab manual, in particular it did not fulfill
PR6 and PR4.
- PR6: If a user that has already logged in attempts to send a HELLO-FROM log-in request, the server must respond with a BAD-RQST-HDR message.

- PR4: If a user logs in with an invalid username, the server must send a BAD-RQST-BODY message in response.

the change to meet pr6 is necessary to allow the client to retransmit HELLO-FROM and get a suitable acknowledgement if the first HELLO they received was corrupted.
VUnetid= tfr216