### PR TITLE
Fix handleGet

### DIFF
--- a/unreliable_chat_check/BrokenChatServerLocal.go
+++ b/unreliable_chat_check/BrokenChatServerLocal.go
@@ -390,7 +390,7 @@ func handleGet(message string, addr net.Addr, output BrokenMessageOutputStream) 
 	if _, ok := cb.GetUser(addr); ok {
 		if match := regexGet.FindStringSubmatch(message); match != nil {
 			var b strings.Builder
-			b.WriteString("VALUE ")
+			b.WriteString(fmt.Sprintf("VALUE %s",match[3]))
 			switch match[3] {
 			case "DROP":
 				b.WriteString(fmt.Sprintf("%f", localSettings.drop))


### PR DESCRIPTION
The lab manual states that the server sends a message in the format "VALUE <name> <value> (<upper>)\n" upon receiving a  valid GET request.  Currently, the server only returns "VALUE <value> (<upper>)\n" -> the message is missing the name of the setting. This commit fixes that issue