### PR TITLE
[HTTP Server] Fixed issues with check.py

### DIFF
--- a/http_server_check/check.py
+++ b/http_server_check/check.py
@@ -23,7 +23,7 @@ def generate_message(min_len=32, max_len=64):
 class TestException(Exception):
     pass
 
-def handle_pexpect(child_process, processes_to_terminate, expect_string, output_buffer, step, timeout=1):
+def handle_pexpect(child_process, processes_to_terminate, expect_string, output_buffer, step, timeout=3):
     try:
         child_process.expect(expect_string, timeout=timeout)
         output_buffer += child_process.before + child_process.after
@@ -89,6 +89,8 @@ def index_reachable():
 def not_found_page_reachable():
     __, _ = start_server()
     PAGE_PATH = ''.join(random.choice(string.ascii_letters) for _ in range(random.randint(8, 16)))
+    PAGE_PATH = f'/{PAGE_PATH}'
+
     
     response = handle_httpconnection_request(PAGE_PATH, "GET")
 
@@ -232,6 +234,7 @@ def check_index_is_visible():
 def check_404_is_visible():
     __, _ = start_server()
     PAGE_PATH = ''.join(random.choice(string.ascii_letters) for _ in range(random.randint(8, 16)))
+    PAGE_PATH = f'/{PAGE_PATH}'
 
     response = handle_httpconnection_request(PAGE_PATH, "GET")
     content = response.read()


### PR DESCRIPTION
# Problems solved

1. Fixed a problem consisting of the `handle_pexpect` function not having enough timeout to wait for the server to run. <br>This means that any possible delay in starting the server would result in the test failing.

2. When testing for the **404 status code**, a random string is generated for a path. However, that path does not start with a `/` character, marking the request as invalid, rather than requesting an invalid page.

From [RFC2016](https://www.ietf.org/rfc/rfc2616.txt):

> The Request-Line begins with a method token, followed by the
   Request-URI and the protocol version, and ending with CRLF. The
   elements are separated by SP characters. No CR or LF is allowed
   except in the final CRLF sequence.
>
> Request-Line   = `Method SP Request-URI SP HTTP-Version CRLF`

> 5.1.2 Request-URI
>
> The Request-URI is a Uniform Resource Identifier (section 3.2) and
> identifies the resource upon which to apply the request.
> 
> Request-URI    = "*" | absoluteURI | abs_path | authority

In this sequence, `abs_path` will always start with a `/`, as per UNIX specifications.


### VU id: `dha242`