### PR TITLE
unreliable-chat-client: setting BURST-LEN through client now works

### DIFF
--- a/unreliable_chat_check/BrokenChatServerLocal.go
+++ b/unreliable_chat_check/BrokenChatServerLocal.go
@@ -422,6 +422,7 @@ func handleSetSelect(message string, addr net.Addr, output BrokenMessageOutputSt
 	split := strings.Split(message, " ")
 	switch split[1] {
 	case "BURST-LEN":
+		handleSetRange(message, addr, output)
 	case "DELAY-LEN":
 		handleSetRange(message, addr, output)
 	default:


### PR DESCRIPTION
when trying to change BURST-LEN within a client in the old code, it would not do anything, because the server does nothing in this case. I assume it was assumed that leaving case "BURST-LEN" empty would cause to do the same as DELAY-LEN but it does not. Now it does.

VU-net ID: lvo233